### PR TITLE
Reduce particle creation count universally

### DIFF
--- a/GameData/RealPlume/000_Generic_Plumes/000_zRealPlume.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/000_zRealPlume.cfg
@@ -24,7 +24,7 @@
     }
     @PLUME:HAS[~emissionMult[]],*
     {
-        %emissionMult = 1
+        %emissionMult = 0.5
     }
     @PLUME:HAS[~speed[]],*
     {


### PR DESCRIPTION
Reduce particle creation count universally. This appears (for me) to reduce the frequency of GC (garbage collection) related pauses. I often also reduce the activeParticles count to 4000 to help with performance as well.

Tested on a 60+ aerobee stage, as well as on plume-heavy R7 rockets.
