### PR TITLE
RealPlume smoke performance rebalance

### DIFF
--- a/GameData/RealPlume/000_Generic_Plumes/Alcolox-Lower-A6.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Alcolox-Lower-A6.cfg
@@ -172,8 +172,8 @@
                 }
                 emission
                 {
-                  density = 1.0 2
-                  density = 0.8 1.2
+                  density = 1.0 1.5
+                  density = 0.8 0.8
                   density = 0.2 1
                   density = 0.1 1
                   density = 0.05 1
@@ -184,9 +184,9 @@
                 }
                 energy
                 {
-                  density = 1.0 2
-                  density = 0.3 2
-                  density = 0.05 1
+                  density = 1.0 1
+                  density = 0.3 1
+                  density = 0.05 0.5
                   density = 0.0 0
                 }
                 size

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower-F1.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower-F1.cfg
@@ -176,21 +176,21 @@
                 }
                 emission
                 {
-                  density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1.2
-                  density = 0.05 1.5
-                  density = 0.0 1.7
+                  density = 1.0 1.5
+                  density = 0.8 0.9
+                  density = 0.2 0.75
+                  density = 0.1 0.9
+                  density = 0.05 1.125
+                  density = 0.0 1.275
                   power = 1 1
                   power = 0.01 0.2
                   power = 0 0
                 }
                 energy
                 {
-                  density = 1.0 2
-                  density = 0.3 2
-                  density = 0.05 1
+                  density = 1.0 1.5
+                  density = 0.3 1.5
+                  density = 0.05 0.75
                   density = 0.0 0
                 }
                 size

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower.cfg
@@ -292,21 +292,21 @@
                 }
                 emission
                 {
-                  density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1.2
-                  density = 0.05 1.5
-                  density = 0.0 1.7
+                  density = 1.0 1
+                  density = 0.8 0.6
+                  density = 0.2 0.5
+                  density = 0.1 0.6
+                  density = 0.05 0.75
+                  density = 0.0 0.85
                   power = 1 1
                   power = 0.01 0.2
                   power = 0 0
                 }
                 energy
                 {
-                  density = 1.0 2
-                  density = 0.3 2
-                  density = 0.05 1
+                  density = 1.0 1
+                  density = 0.3 1
+                  density = 0.05 0.5
                   density = 0.0 0
                 }
             }

--- a/GameData/RealPlume/000_Generic_Plumes/Solid-Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Solid-Lower.cfg
@@ -160,8 +160,8 @@
                 }
                 emission
                 {
-                  density = 1.0 5.0
-                  density = 0.05 4
+                  density = 1.0 2.5
+                  density = 0.05 2
                   density = 0.0 0
                   power = 1 1
                   power = 0.01 0.2
@@ -169,8 +169,8 @@
                 }
                 energy
                 {
-                  density = 1.0 5
-                  density = 0.3 5
+                  density = 1.0 2.5
+                  density = 0.3 2.5
                   density = 0.05 0.01
                   density = 0.0 0.0
                 }


### PR DESCRIPTION
Reduce the particle creation and lifetime for some engines.

Improves performance of RealPlume by keeping a lower control value of smoke particle creation and lifetime.
