### PR TITLE
No changes required for 1.2?

### DIFF
--- a/RealPlume.netkan
+++ b/RealPlume.netkan
@@ -3,7 +3,7 @@
     "spec_version"      : "v1.4",
     "$kref"             : "#/ckan/github/KSP-RO/RealPlume",
     "ksp_version_min"   : "1.0.4",
-    "ksp_version_max"   : "1.1",
+    "ksp_version_max"   : "1.2",
     "name"              : "Real Plume",
     "identifier"        : "RealPlume",
     "abstract"          : "A set of effects and basic configs that can be attached to any engine as appropriate.  Requires secondary configs to function correctly.",


### PR DESCRIPTION
According to RealPlume-StockConfigs people, the RealPlume configs work fine with the updated SmokeScreen for KSP 1.2
