### PR TITLE
Shuriken particle support

### DIFF
--- a/GameData/RealPlume/000_Generic_Plumes/Alcolox-Lower-A6.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Alcolox-Lower-A6.cfg
@@ -4,7 +4,7 @@
     {
         %Alcolox-Lower-A6
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Alcolox-Lower-A6]/transformName$
@@ -32,7 +32,7 @@
                   power = 0 15
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Alcolox-Lower-A6]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Ammonialox.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Ammonialox.cfg
@@ -4,7 +4,7 @@
     {
         %Ammonialox
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Ammonialox]/transformName$
@@ -31,7 +31,7 @@
                   power = 0 15
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Ammonialox]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Hydrogen-NTR-HighTemp.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hydrogen-NTR-HighTemp.cfg
@@ -4,7 +4,7 @@
     {
         %Hydrogen-NTR-HighTemp
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hydrogen-NTR-HighTemp]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Hydrogen-NTR.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hydrogen-NTR.cfg
@@ -4,7 +4,7 @@
     {
         %Hydrogen-NTR
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hydrogen-NTR]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Hydrolox-Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hydrolox-Lower.cfg
@@ -4,7 +4,7 @@
     {
         %Hydrolox-Lower
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hydrolox-Lower]/transformName$
@@ -32,7 +32,7 @@
                   power = 0 15
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hydrolox-Lower]/transformName$
@@ -69,7 +69,7 @@
                   density = 0 0
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hydrolox-Lower]/transformName$
@@ -154,7 +154,7 @@
                   density = 0.0 0.45
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hydrolox-Lower]/transformName$
@@ -239,7 +239,7 @@
                   density = 0.0 0.45
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hydrolox-Lower]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Hydrolox-Upper.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hydrolox-Upper.cfg
@@ -4,7 +4,7 @@
     {
         %Hydrolox-Upper
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hydrolox-Upper]/transformName$
@@ -32,7 +32,7 @@
                   power = 0 15
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hydrolox-Upper]/transformName$
@@ -125,7 +125,7 @@
                   density = 0.0 0.55
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hydrolox-Upper]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Hydynelox-A7.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hydynelox-A7.cfg
@@ -4,7 +4,7 @@
     {
         %Hydynelox-A7
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hydynelox-A7]/transformName$
@@ -32,7 +32,7 @@
                   power = 0 15
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hydynelox-A7]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Apollo-SM.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Apollo-SM.cfg
@@ -4,7 +4,7 @@
     {
         %Hypergolic-Apollo-SM
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hypergolic-Apollo-SM]/transformName$
@@ -32,7 +32,7 @@
                   power = 0 15
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hypergolic-Apollo-SM]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Lower.cfg
@@ -4,7 +4,7 @@
     {
         %Hypergolic-Lower
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hypergolic-Lower]/transformName$
@@ -32,7 +32,7 @@
                   power = 0 15
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hypergolic-Lower]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic-OMS-Red.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic-OMS-Red.cfg
@@ -4,7 +4,7 @@
     {
         %Hypergolic-OMS-Red
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hypergolic-OMS-Red]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic-OMS-White.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic-OMS-White.cfg
@@ -4,7 +4,7 @@
     {
         %Hypergolic-OMS-White
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hypergolic-OMS-White]/transformName$
@@ -35,7 +35,7 @@
                   power = 0 15
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hypergolic-OMS-White]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Upper.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Upper.cfg
@@ -4,7 +4,7 @@
     {
         %Hypergolic-Upper
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hypergolic-Upper]/transformName$
@@ -32,7 +32,7 @@
                   power = 0 15
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hypergolic-Upper]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Vernier.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Vernier.cfg
@@ -4,7 +4,7 @@
     {
         %Hypergolic-Vernier
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Hypergolic-Vernier]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Ion-Argon-Gridded.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Ion-Argon-Gridded.cfg
@@ -5,7 +5,7 @@
     {
         %Ion-Argon-Gridded
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
                 transformName = #$../../../PLUME[Ion-Argon-Gridded]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Ion-Krypton-Gridded.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Ion-Krypton-Gridded.cfg
@@ -4,7 +4,7 @@
     {
         %Ion-Krypton-Gridded
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
                 transformName = #$../../../PLUME[Ion-Krypton-Gridded]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Ion-Krypton-Hall.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Ion-Krypton-Hall.cfg
@@ -4,7 +4,7 @@
     {
         %Ion-Krypton-Hall
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
                 transformName = #$../../../PLUME[Ion-Krypton-Hall]/transformName$
@@ -42,7 +42,7 @@
                   density = 0 4.78
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
                 transformName = #$../../../PLUME[Ion-Krypton-Hall]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Ion-Xenon-Gridded.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Ion-Xenon-Gridded.cfg
@@ -4,7 +4,7 @@
     {
         %Ion-Xenon-Gridded
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
                 transformName = #$../../../PLUME[Ion-Xenon-Gridded]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Ion-Xenon-Hall.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Ion-Xenon-Hall.cfg
@@ -5,7 +5,7 @@
     {
         %Ion-Xenon-Hall
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
                 transformName = #$../../../PLUME[Ion-Xenon-Hall]/transformName$
@@ -45,7 +45,7 @@
                   density = 0 4.78
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
                 transformName = #$../../../PLUME[Ion-Xenon-Hall]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower-F1.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower-F1.cfg
@@ -4,7 +4,7 @@
     {
         %Kerolox-Lower-F1
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Kerolox-Lower-F1]/transformName$
@@ -37,7 +37,7 @@
                   power = 1 5
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Kerolox-Lower-F1]/transformName$
@@ -141,7 +141,7 @@
                   density = 0.0 0.8
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Kerolox-Lower-F1]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower.cfg
@@ -4,7 +4,7 @@
     {
         %Kerolox-Lower
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Kerolox-Lower]/transformName$
@@ -27,7 +27,7 @@
                 fixedEmissions = false
                 randomInitalVelocityOffsetMaxRadius = 0.2
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Kerolox-Lower]/transformName$
@@ -131,7 +131,7 @@
                   density = 0.0 0.4
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Kerolox-Lower]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Upper.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Upper.cfg
@@ -4,7 +4,7 @@
     {
         %Kerolox-Upper
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Kerolox-Upper]/transformName$
@@ -27,7 +27,7 @@
                 fixedEmissions = false
                 randomInitalVelocityOffsetMaxRadius = 0.2
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Kerolox-Upper]/transformName$
@@ -131,7 +131,7 @@
                   density = 0.0 0.4
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Kerolox-Upper]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Vernier.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Vernier.cfg
@@ -4,7 +4,7 @@
     {
         %Kerolox-Vernier
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Kerolox-Vernier]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Solid-Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Solid-Lower.cfg
@@ -4,7 +4,7 @@
     {
         %Solid-Lower
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Lower]/transformName$
@@ -27,7 +27,7 @@
                 fixedEmissions = false
                 randomInitalVelocityOffsetMaxRadius = 0.2
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Lower]/transformName$
@@ -111,7 +111,7 @@
                   density = 0.2 0.55
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Lower]/transformName$
@@ -184,7 +184,7 @@
                   density = 0.0 8
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Lower]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Solid-Sepmotor.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Solid-Sepmotor.cfg
@@ -4,7 +4,7 @@
     {
         %Solid-Sepmotor
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Sepmotor]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Solid-Upper.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Solid-Upper.cfg
@@ -4,7 +4,7 @@
     {
         %Solid-Upper
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Upper]/transformName$
@@ -27,7 +27,7 @@
                 fixedEmissions = false
                 randomInitalVelocityOffsetMaxRadius = 0.2
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Upper]/transformName$
@@ -111,7 +111,7 @@
                   density = 0.2 0.55
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Upper]/transformName$
@@ -184,7 +184,7 @@
                   density = 0.0 7
                 }
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Upper]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Solid-Vacuum.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Solid-Vacuum.cfg
@@ -4,7 +4,7 @@
     {
         %Solid-Vacuum
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Vacuum]/transformName$
@@ -27,7 +27,7 @@
                 fixedEmissions = false
                 randomInitalVelocityOffsetMaxRadius = 0
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Vacuum]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Turbofan.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Turbofan.cfg
@@ -4,7 +4,7 @@
     {
         %Turbofan
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 
                 transformName = #$../../../PLUME[Turbofan]/transformName$
@@ -51,7 +51,7 @@
         }
         %Turbofan-Spool
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Turbofan]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/Turbojet.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Turbojet.cfg
@@ -4,7 +4,7 @@
     {
         %Turbojet
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
                 transformName = #$../../../PLUME[Turbojet]/transformName$
@@ -44,7 +44,7 @@
 				  density = 0.0 0.3
 				}
             }
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
                 transformName = #$../../../PLUME[Turbojet]/transformName$
@@ -108,7 +108,7 @@
         }
         %Turbojet-Spool
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Turbojet]/transformName$

--- a/GameData/RealPlume/000_Generic_Plumes/zRN_Decoupler.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/zRN_Decoupler.cfg
@@ -4,7 +4,7 @@
     {
         %zRN_Decoupler
         {
-            MODEL_MULTI_PARTICLE_PERSIST
+            MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
                 transformName = #$../../../PLUME[zRN_Decoupler]/transformName$


### PR DESCRIPTION
Changes the plume configs to have support for the new shuriken particle
system that SmokeScreen recently added support for in 2.7.0