### PR TITLE
Smoke change

### DIFF
--- a/GameData/RealPlume/000_Generic_Plumes/000_zRealPlume.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/000_zRealPlume.cfg
@@ -38,10 +38,6 @@
     {
         plumeScale = #$fixedScale$
     }
-	@PLUME:HAS[~smokeScale[]],*
-    {
-        smokeScale = #$fixedScale$
-    }
     @PLUME:HAS[~flarePosition[]],*
     {
         %flarePosition = #$localPosition[0]$,$localPosition[1]$,$localPosition[2]$
@@ -49,9 +45,5 @@
     @PLUME:HAS[~plumePosition[]],*
     {
         %plumePosition = #$localPosition[0]$,$localPosition[1]$,$localPosition[2]$
-    }
-	@PLUME:HAS[~smokePosition[]],*
-    {
-        %smokePosition = #$localPosition[0]$,$localPosition[1]$,$localPosition[2]$
     }
 }

--- a/GameData/RealPlume/000_Generic_Plumes/000_zRealPlume.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/000_zRealPlume.cfg
@@ -38,6 +38,10 @@
     {
         plumeScale = #$fixedScale$
     }
+	@PLUME:HAS[~smokeScale[]],*
+    {
+        smokeScale = #$fixedScale$
+    }
     @PLUME:HAS[~flarePosition[]],*
     {
         %flarePosition = #$localPosition[0]$,$localPosition[1]$,$localPosition[2]$
@@ -45,5 +49,9 @@
     @PLUME:HAS[~plumePosition[]],*
     {
         %plumePosition = #$localPosition[0]$,$localPosition[1]$,$localPosition[2]$
+    }
+	@PLUME:HAS[~smokePosition[]],*
+    {
+        %smokePosition = #$localPosition[0]$,$localPosition[1]$,$localPosition[2]$
     }
 }

--- a/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-125.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-125.cfg
@@ -9,8 +9,8 @@
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Cryogenic-UpperLower-125]/transformName$
                 localRotation = #$../../../PLUME[Cryogenic-UpperLower-125]/localRotation[0]$,$../../../PLUME[Cryogenic-UpperLower-125]/localRotation[1]$,$../../../PLUME[Cryogenic-UpperLower-125]/localRotation[2]$
-                localPosition = #$../../../PLUME[Cryogenic-UpperLower-125]/smokePosition[0]$,$../../../PLUME[Cryogenic-UpperLower-125]/smokePosition[1]$,$../../../PLUME[Cryogenic-UpperLower-125]/smokePosition[2]$
-                fixedScale    = #$../../../PLUME[Cryogenic-UpperLower-125]/smokeScale$
+                localPosition = #$../../../PLUME[Cryogenic-UpperLower-125]/flarePosition[0]$,$../../../PLUME[Cryogenic-UpperLower-125]/flarePosition[1]$,$../../../PLUME[Cryogenic-UpperLower-125]/flarePosition[2]$
+                fixedScale    = #$../../../PLUME[Cryogenic-UpperLower-125]/flareScale$
                 //
                 name = smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet

--- a/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-125.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-125.cfg
@@ -9,8 +9,8 @@
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Cryogenic-UpperLower-125]/transformName$
                 localRotation = #$../../../PLUME[Cryogenic-UpperLower-125]/localRotation[0]$,$../../../PLUME[Cryogenic-UpperLower-125]/localRotation[1]$,$../../../PLUME[Cryogenic-UpperLower-125]/localRotation[2]$
-                localPosition = #$../../../PLUME[Cryogenic-UpperLower-125]/flarePosition[0]$,$../../../PLUME[Cryogenic-UpperLower-125]/flarePosition[1]$,$../../../PLUME[Cryogenic-UpperLower-125]/flarePosition[2]$
-                fixedScale    = #$../../../PLUME[Cryogenic-UpperLower-125]/flareScale$
+                localPosition = #$../../../PLUME[Cryogenic-UpperLower-125]/smokePosition[0]$,$../../../PLUME[Cryogenic-UpperLower-125]/smokePosition[1]$,$../../../PLUME[Cryogenic-UpperLower-125]/smokePosition[2]$
+                fixedScale    = #$../../../PLUME[Cryogenic-UpperLower-125]/smokeScale$
                 //
                 name = smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet

--- a/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-25.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-25.cfg
@@ -9,8 +9,8 @@
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Cryogenic-UpperLower-25]/transformName$
                 localRotation = #$../../../PLUME[Cryogenic-UpperLower-25]/localRotation[0]$,$../../../PLUME[Cryogenic-UpperLower-25]/localRotation[1]$,$../../../PLUME[Cryogenic-UpperLower-25]/localRotation[2]$
-                localPosition = #$../../../PLUME[Cryogenic-UpperLower-25]/smokePosition[0]$,$../../../PLUME[Cryogenic-UpperLower-25]/smokePosition[1]$,$../../../PLUME[Cryogenic-UpperLower-25]/smokePosition[2]$
-                fixedScale    = #$../../../PLUME[Cryogenic-UpperLower-25]/smokeScale$
+                localPosition = #$../../../PLUME[Cryogenic-UpperLower-25]/flarePosition[0]$,$../../../PLUME[Cryogenic-UpperLower-25]/flarePosition[1]$,$../../../PLUME[Cryogenic-UpperLower-25]/flarePosition[2]$
+                fixedScale    = #$../../../PLUME[Cryogenic-UpperLower-25]/flareScale$
                 //
                 name = smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet

--- a/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-25.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-25.cfg
@@ -9,8 +9,8 @@
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Cryogenic-UpperLower-25]/transformName$
                 localRotation = #$../../../PLUME[Cryogenic-UpperLower-25]/localRotation[0]$,$../../../PLUME[Cryogenic-UpperLower-25]/localRotation[1]$,$../../../PLUME[Cryogenic-UpperLower-25]/localRotation[2]$
-                localPosition = #$../../../PLUME[Cryogenic-UpperLower-25]/flarePosition[0]$,$../../../PLUME[Cryogenic-UpperLower-25]/flarePosition[1]$,$../../../PLUME[Cryogenic-UpperLower-25]/flarePosition[2]$
-                fixedScale    = #$../../../PLUME[Cryogenic-UpperLower-25]/flareScale$
+                localPosition = #$../../../PLUME[Cryogenic-UpperLower-25]/smokePosition[0]$,$../../../PLUME[Cryogenic-UpperLower-25]/smokePosition[1]$,$../../../PLUME[Cryogenic-UpperLower-25]/smokePosition[2]$
+                fixedScale    = #$../../../PLUME[Cryogenic-UpperLower-25]/smokeScale$
                 //
                 name = smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet

--- a/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-375.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-375.cfg
@@ -37,8 +37,8 @@
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Cryogenic-UpperLower-375]/transformName$
                 localRotation = #$../../../PLUME[Cryogenic-UpperLower-375]/localRotation[0]$,$../../../PLUME[Cryogenic-UpperLower-375]/localRotation[1]$,$../../../PLUME[Cryogenic-UpperLower-375]/localRotation[2]$
-                localPosition = #$../../../PLUME[Cryogenic-UpperLower-375]/flarePosition[0]$,$../../../PLUME[Cryogenic-UpperLower-375]/flarePosition[1]$,$../../../PLUME[Cryogenic-UpperLower-375]/flarePosition[2]$
-                fixedScale    = #$../../../PLUME[Cryogenic-UpperLower-375]/flareScale$
+                localPosition = #$../../../PLUME[Cryogenic-UpperLower-375]/smokePosition[0]$,$../../../PLUME[Cryogenic-UpperLower-375]/smokePosition[1]$,$../../../PLUME[Cryogenic-UpperLower-375]/smokePosition[2]$
+                fixedScale    = #$../../../PLUME[Cryogenic-UpperLower-375]/smokeScale$
                 //
                 name = smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet

--- a/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-375.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-375.cfg
@@ -37,8 +37,8 @@
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Cryogenic-UpperLower-375]/transformName$
                 localRotation = #$../../../PLUME[Cryogenic-UpperLower-375]/localRotation[0]$,$../../../PLUME[Cryogenic-UpperLower-375]/localRotation[1]$,$../../../PLUME[Cryogenic-UpperLower-375]/localRotation[2]$
-                localPosition = #$../../../PLUME[Cryogenic-UpperLower-375]/smokePosition[0]$,$../../../PLUME[Cryogenic-UpperLower-375]/smokePosition[1]$,$../../../PLUME[Cryogenic-UpperLower-375]/smokePosition[2]$
-                fixedScale    = #$../../../PLUME[Cryogenic-UpperLower-375]/smokeScale$
+                localPosition = #$../../../PLUME[Cryogenic-UpperLower-375]/flarePosition[0]$,$../../../PLUME[Cryogenic-UpperLower-375]/flarePosition[1]$,$../../../PLUME[Cryogenic-UpperLower-375]/flarePosition[2]$
+                fixedScale    = #$../../../PLUME[Cryogenic-UpperLower-375]/flareScale$
                 //
                 name = smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet

--- a/GameData/RealPlume/000_Generic_Plumes/Solid-Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Solid-Lower.cfg
@@ -116,8 +116,8 @@
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Lower]/transformName$
                 localRotation = #$../../../PLUME[Solid-Lower]/localRotation[0]$,$../../../PLUME[Solid-Lower]/localRotation[1]$,$../../../PLUME[Solid-Lower]/localRotation[2]$
-                localPosition = #$../../../PLUME[Solid-Lower]/plumePosition[0]$,$../../../PLUME[Solid-Lower]/plumePosition[1]$,$../../../PLUME[Solid-Lower]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Solid-Lower]/plumeScale$
+                localPosition = #$../../../PLUME[Solid-Lower]/smokePosition[0]$,$../../../PLUME[Solid-Lower]/smokePosition[1]$,$../../../PLUME[Solid-Lower]/smokePosition[2]$
+                fixedScale    = #$../../../PLUME[Solid-Lower]/smokeScale$
                 emissionMult  = #$../../../PLUME[Solid-Lower]/emissionMult$
                 //
                 name = smoke

--- a/GameData/RealPlume/000_Generic_Plumes/Solid-Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Solid-Lower.cfg
@@ -116,8 +116,8 @@
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Lower]/transformName$
                 localRotation = #$../../../PLUME[Solid-Lower]/localRotation[0]$,$../../../PLUME[Solid-Lower]/localRotation[1]$,$../../../PLUME[Solid-Lower]/localRotation[2]$
-                localPosition = #$../../../PLUME[Solid-Lower]/smokePosition[0]$,$../../../PLUME[Solid-Lower]/smokePosition[1]$,$../../../PLUME[Solid-Lower]/smokePosition[2]$
-                fixedScale    = #$../../../PLUME[Solid-Lower]/smokeScale$
+                localPosition = #$../../../PLUME[Solid-Lower]/plumePosition[0]$,$../../../PLUME[Solid-Lower]/plumePosition[1]$,$../../../PLUME[Solid-Lower]/plumePosition[2]$
+                fixedScale    = #$../../../PLUME[Solid-Lower]/plumeScale$
                 emissionMult  = #$../../../PLUME[Solid-Lower]/emissionMult$
                 //
                 name = smoke

--- a/GameData/RealPlume/000_Generic_Plumes/Solid-Upper.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Solid-Upper.cfg
@@ -116,8 +116,8 @@
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Upper]/transformName$
                 localRotation = #$../../../PLUME[Solid-Upper]/localRotation[0]$,$../../../PLUME[Solid-Upper]/localRotation[1]$,$../../../PLUME[Solid-Upper]/localRotation[2]$
-                localPosition = #$../../../PLUME[Solid-Upper]/plumePosition[0]$,$../../../PLUME[Solid-Upper]/plumePosition[1]$,$../../../PLUME[Solid-Upper]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Solid-Upper]/plumeScale$
+                localPosition = #$../../../PLUME[Solid-Upper]/smokePosition[0]$,$../../../PLUME[Solid-Upper]/smokePosition[1]$,$../../../PLUME[Solid-Upper]/smokePosition[2]$
+                fixedScale    = #$../../../PLUME[Solid-Upper]/smokeScale$
                 emissionMult  = #$../../../PLUME[Solid-Upper]/emissionMult$
                 //
                 name = smoke

--- a/GameData/RealPlume/000_Generic_Plumes/Solid-Upper.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Solid-Upper.cfg
@@ -116,8 +116,8 @@
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Solid-Upper]/transformName$
                 localRotation = #$../../../PLUME[Solid-Upper]/localRotation[0]$,$../../../PLUME[Solid-Upper]/localRotation[1]$,$../../../PLUME[Solid-Upper]/localRotation[2]$
-                localPosition = #$../../../PLUME[Solid-Upper]/smokePosition[0]$,$../../../PLUME[Solid-Upper]/smokePosition[1]$,$../../../PLUME[Solid-Upper]/smokePosition[2]$
-                fixedScale    = #$../../../PLUME[Solid-Upper]/smokeScale$
+                localPosition = #$../../../PLUME[Solid-Upper]/plumePosition[0]$,$../../../PLUME[Solid-Upper]/plumePosition[1]$,$../../../PLUME[Solid-Upper]/plumePosition[2]$
+                fixedScale    = #$../../../PLUME[Solid-Upper]/plumeScale$
                 emissionMult  = #$../../../PLUME[Solid-Upper]/emissionMult$
                 //
                 name = smoke

--- a/GameData/RealPlume/000_Generic_Plumes/Turbofan.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Turbofan.cfg
@@ -55,8 +55,8 @@
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Turbofan]/transformName$
-                fixedScale    = #$../../../PLUME[Turbofan]/plumeScale$
-                localPosition = #$../../../PLUME[Turbofan]/plumePosition[0]$,$../../../PLUME[Turbofan]/plumePosition[1]$,$../../../PLUME[Turbofan]/plumePosition[2]$
+                fixedScale    = #$../../../PLUME[Turbofan]/smokeScale$
+                localPosition = #$../../../PLUME[Turbofan]/smokePosition[0]$,$../../../PLUME[Turbofan]/smokePosition[1]$,$../../../PLUME[Turbofan]/smokePosition[2]$
                 //
                 name = smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet

--- a/GameData/RealPlume/000_Generic_Plumes/Turbofan.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Turbofan.cfg
@@ -55,8 +55,8 @@
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Turbofan]/transformName$
-                fixedScale    = #$../../../PLUME[Turbofan]/smokeScale$
-                localPosition = #$../../../PLUME[Turbofan]/smokePosition[0]$,$../../../PLUME[Turbofan]/smokePosition[1]$,$../../../PLUME[Turbofan]/smokePosition[2]$
+                fixedScale    = #$../../../PLUME[Turbofan]/plumeScale$
+                localPosition = #$../../../PLUME[Turbofan]/plumePosition[0]$,$../../../PLUME[Turbofan]/plumePosition[1]$,$../../../PLUME[Turbofan]/plumePosition[2]$
                 //
                 name = smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet

--- a/GameData/RealPlume/000_Generic_Plumes/Turbojet.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Turbojet.cfg
@@ -112,8 +112,8 @@
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Turbojet]/transformName$
-                fixedScale    = #$../../../PLUME[Turbojet]/smokeScale$
-                localPosition = #$../../../PLUME[Turbojet]/smokePosition[0]$,$../../../PLUME[Turbojet]/smokePosition[1]$,$../../../PLUME[Turbojet]/smokePosition[2]$
+                fixedScale    = #$../../../PLUME[Turbojet]/plumeScale$
+                localPosition = #$../../../PLUME[Turbojet]/plumePosition[0]$,$../../../PLUME[Turbojet]/plumePosition[1]$,$../../../PLUME[Turbojet]/plumePosition[2]$
                 //
                 name = smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet

--- a/GameData/RealPlume/000_Generic_Plumes/Turbojet.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Turbojet.cfg
@@ -112,8 +112,8 @@
             {
                 //Get the inputs from the other config.
                 transformName = #$../../../PLUME[Turbojet]/transformName$
-                fixedScale    = #$../../../PLUME[Turbojet]/plumeScale$
-                localPosition = #$../../../PLUME[Turbojet]/plumePosition[0]$,$../../../PLUME[Turbojet]/plumePosition[1]$,$../../../PLUME[Turbojet]/plumePosition[2]$
+                fixedScale    = #$../../../PLUME[Turbojet]/smokeScale$
+                localPosition = #$../../../PLUME[Turbojet]/smokePosition[0]$,$../../../PLUME[Turbojet]/smokePosition[1]$,$../../../PLUME[Turbojet]/smokePosition[2]$
                 //
                 name = smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet


### PR DESCRIPTION
I've always been annoyed that sometimes the smoke effects are translated improperly even if the plume and flare both look good. This adds the ability to add additional parameters to MM configs that let you scale and translate the smoke effects individually of the plume and flare. I've included an example config just in case anyone needs a reference.
```javascript
@PART[engineName]:FOR[RealPlume]:NEEDS[SmokeScreen] //
{
    PLUME
    {
        name = plumeName
        transformName = thrustTransform
        localRotation = 0,0,0
        plumePosition = 0,0,0
        flarePosition = 0,0,0
        smokePosition = 0,0,0
        plumeScale = 1
        flareScale = 1
        smokeScale = 1
        energy = 1
        speed = 1
    }
    @MODULE[ModuleEngines*]
    {
        %powerEffectName = plumeName
    }
}
```
P.S.  The ability to only use localPosition and fixedScale still works correctly