### PR TITLE
Allow the RCS FX to coexist with RealPlume

### DIFF
--- a/GameData/RealPlume/000_Generic_Plumes/000_EFFECTS_Remover.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/000_EFFECTS_Remover.cfg
@@ -1,6 +1,22 @@
+//  ==================================================
+//  Tag all parts that include RCS FX effects.
+//  ==================================================
+
+@PART[*]:HAS[@MODULE[ModuleRCSFX]]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+{
+    @MODULE[ModuleRCSFX]:HAS[#runningEffectName[*]],*
+    {
+        plumeToKeep = #$runningEffectName$
+    }
+}
+
+//  ==================================================
+//  Remove all deprecated FX parameters from all parts
+//  that implement plumes.
+//  ==================================================
+
 @PART[*]:HAS[@PLUME[*]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
-    !EFFECTS,* {}
     !fx_gasJet_tiny = DELETE
     !fx_exhaustFlame_blue_small = DELETE
     !fx_exhaustFlame_yellow = DELETE
@@ -11,9 +27,9 @@
     !fx_exhaustLight_blue = DELETE
     !fx_smokeTrail_medium = DELETE
     !fx_smokeTrail_light = DELETE
-    !fx_gasBurst_white = DELETE
     !fx_exhaustSparks_flameout = DELETE
     !fx_exhaustSparks_yellow = DELETE
+
     !sound_jet_low = DELETE
     !sound_jet_deep = DELETE
     !sound_vent_soft = DELETE
@@ -21,8 +37,47 @@
     !sound_vent_medium = DELETE
     !sound_rocket_hard = DELETE
     !sound_rocket_mini = DELETE
-    !sound_decoupler_fire = DELETE
     !sound_explosion_low = DELETE
-    !sound_parachute_open = DELETE
-    !sound_parachute_single = DELETE
+
+    @MODULE[ModuleEngines*],*
+    {
+        !fxOffset = NULL
+    }
+}
+
+//  ==================================================
+//  Decoupler parts.
+//  ==================================================
+
+@PART[*]:HAS[@PLUME[zRN_Decoupler],@MODULE[ModuleDecouple]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+    !fx_gasBurst_white = DELETE
+
+    !sound_decoupler_fire = DELETE
+}
+
+//  ==================================================
+//  Engine parts.
+//  ==================================================
+
+@PART[*]:HAS[@PLUME[*],@MODULE[ModuleEngines*],!MODULE[ModuleDecouple],!MODULE[ModuleRCSFX]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+    !EFFECTS,*{}
+}
+
+//  ==================================================
+//  RCS part.
+//  ==================================================
+
+@PART[*]:HAS[@PLUME[*],@MODULE[ModuleRCSFX]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+{
+    MM_NODE_LOOP
+    {
+        !EFFECTS:HAS[~#$@MODULE[ModuleRCSFX]/plumeToKeep$],*{}
+    }
+
+    @MODULE[ModuleRCSFX],*
+    {
+        !plumeToKeep = NULL
+    }
 }

--- a/GameData/RealPlume/000_Generic_Plumes/000_EFFECTS_Remover.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/000_EFFECTS_Remover.cfg
@@ -60,13 +60,13 @@
 //  Engine parts.
 //  ==================================================
 
-@PART[*]:HAS[@PLUME[*],@MODULE[ModuleEngines*],!MODULE[ModuleDecouple],!MODULE[ModuleRCSFX]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[*],@MODULE[ModuleEngines*],!MODULE[ModuleRCSFX]]:AFTER[RealPlume]:NEEDS[SmokeScreen]
 {
     !EFFECTS,*{}
 }
 
 //  ==================================================
-//  RCS part.
+//  RCS parts.
 //  ==================================================
 
 @PART[*]:HAS[@PLUME[*],@MODULE[ModuleRCSFX]]:AFTER[RealPlume]:NEEDS[SmokeScreen]


### PR DESCRIPTION
**Change log:**

* Initial updates to the EFFECTS patcher to allow both the stock RCS plumes and the RealPlume plumes to work for the same part (https://github.com/KSP-RO/RealPlume/issues/24).

**Notes:**

* Might still not work correctly. Initial testing with some of the Coatl Aerospace ProbesPlus parts (that include decoupler, engine and RCS modules in the same part) indicates that the patcher works as expected. SSTU and the RaiderNick packs must be tested for RCS and decoupler compatibility.