### PR TITLE
FloatCurve fixes

### DIFF
--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower-F1.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower-F1.cfg
@@ -215,7 +215,7 @@
                   density = 0.5 3
                   density = 0.2 4
                   density = 0.1 4
-                  density = 0.05
+                  density = 0.05 5
                   density = 0.01 6
                   density = 0.0 7
                   power = 1 1

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower.cfg
@@ -205,7 +205,7 @@
                   density = 0.5 3
                   density = 0.2 4
                   density = 0.1 4
-                  density = 0.05 
+                  density = 0.05 5
                   density = 0.01 6
                   density = 0.0 7
                   power = 1 1

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Upper.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Upper.cfg
@@ -213,7 +213,7 @@
                   density = 0.5 3
                   density = 0.2 4
                   density = 0.1 4
-                  density = 0.05 
+                  density = 0.05 5
                   density = 0.01 6
                   density = 0.0 7
                   power = 1 1


### PR DESCRIPTION
**Change Log:**

* Add some missing float curve values to the kerolox plume configs (https://github.com/KSP-RO/RealPlume/issues/22).

**Notes:**

* There are more plume configs that also cause logspam:

    * Hypergolic-OMS-White
    * Ion-Xenon-Hall
    * Turbofan

But i went through them and they are not missing anything.