### PR TITLE
Support older ModuleManager versions

### DIFF
--- a/GameData/RealPlume/000_Generic_Plumes/Alcolox-Lower-A6.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Alcolox-Lower-A6.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Alcolox-Lower-A6]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Alcolox-Lower-A6
         {
-            plumeIdentifier = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/KerbXflame
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -36,15 +36,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/ssmeflame
                 fixedEmissions = false
                 sizeClamp = 50
@@ -122,11 +122,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -139,7 +139,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq4
-                volume = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -167,7 +167,7 @@
             }
         }
     }
-    @PLUME[Alcolox-Lower-A6]:HAS[~processed]
+    @PLUME[Alcolox-Lower-A6]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Ammonialox.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Ammonialox.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Ammonialox]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Ammonialox]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Ammonialox
         {
-            plumeIdentifier = #$/PLUME[Ammonialox]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Ammonialox]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Ammonialox]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Ammonialox]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Ammonialox]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Ammonialox]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Ammonialox]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Ammonialox]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Ammonialox]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Ammonialox]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Ammonialox]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Ammonialox]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/KerbXflame
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -35,15 +35,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Ammonialox]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Ammonialox]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Ammonialox]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Ammonialox]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Ammonialox]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Ammonialox]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Ammonialox]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Ammonialox]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Ammonialox]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Ammonialox]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Ammonialox]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Ammonialox]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Ammonialox]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Ammonialox]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Ammonialox]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Ammonialox]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/KerbXflame
                 fixedEmissions = false
                 sizeClamp = 50
@@ -121,11 +121,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Ammonialox]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Ammonialox]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Ammonialox]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Ammonialox]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -138,7 +138,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq4
-                volume = #$/PLUME[Ammonialox]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Ammonialox]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -166,7 +166,7 @@
             }
         }
     }
-    @PLUME[Ammonialox]:HAS[~processed]
+    @PLUME[Ammonialox]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-125.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-125.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Cryogenic-UpperLower-125]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Cryogenic-UpperLower-125
         {
-            plumeIdentifier = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/smokePosition$
-                fixedScale    = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/smokeScale$
+                transformName = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/smokePosition$
+                fixedScale    = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/smokeScale$
                 //
-                name = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/plumeIdentifier$-smoke
+                name = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/plumeIdentifier$-smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet
                 speed = 0.0 0.25
                 speed = 1.0 1.0
@@ -84,15 +84,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/Nertea_FX/cryoEngine25-exhaust-1
                 fixedEmissions = false
                 sizeClamp = 50
@@ -168,11 +168,11 @@
             }
             AUDIO
             {
-                #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/plumeIdentifier$-audio
+                #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -213,7 +213,7 @@
             }
         }
     }
-    @PLUME[Cryogenic-UpperLower-125]:HAS[~processed]
+    @PLUME[Cryogenic-UpperLower-125]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-25.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-25.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Cryogenic-UpperLower-25]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Cryogenic-UpperLower-25
         {
-            plumeIdentifier = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/smokePosition$
-                fixedScale    = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/smokeScale$
+                transformName = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/smokePosition$
+                fixedScale    = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/smokeScale$
                 //
-                name = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/plumeIdentifier$-smoke
+                name = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/plumeIdentifier$-smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet
                 speed = 0.0 0.25
                 speed = 1.0 1.0
@@ -84,15 +84,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/Nertea_FX/cryoEngine25-exhaust-2
                 fixedEmissions = false
                 sizeClamp = 50
@@ -168,11 +168,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -213,7 +213,7 @@
             }
         }
     }
-    @PLUME[Cryogenic-UpperLower-25]:HAS[~processed]
+    @PLUME[Cryogenic-UpperLower-25]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-375.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Cryogenic-UpperLower-375.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Cryogenic-UpperLower-375]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Cryogenic-UpperLower-375
         {
-            plumeIdentifier = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/Nertea_FX/cryoEngine375-flare-1
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -36,10 +36,10 @@
 			MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/smokePosition$
-                fixedScale    = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/smokeScale$
+                transformName = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/smokePosition$
+                fixedScale    = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/smokeScale$
                 //
                 name = smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet
@@ -114,15 +114,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/Nertea_FX/cryoEngine375-exhaust-2
                 fixedEmissions = false
                 sizeClamp = 50
@@ -199,11 +199,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -244,7 +244,7 @@
             }
         }
     }
-    @PLUME[Cryogenic-UpperLower-375]:HAS[~processed]
+    @PLUME[Cryogenic-UpperLower-375]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Hydrogen-NTR-HighTemp.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hydrogen-NTR-HighTemp.cfg
@@ -1,22 +1,22 @@
-@PART[*]:HAS[@PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Hydrogen-NTR-HighTemp
         {
-            plumeIdentifier = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/fusionflame
                 fixedEmissions = false
                 sizeClamp = 50
@@ -86,11 +86,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -103,7 +103,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq7
-                volume = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]/plumeScale$
                 pitch = 0.8
                 loop = false
             }
@@ -131,7 +131,7 @@
             }
         }
     }
-    @PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed]
+    @PLUME[Hydrogen-NTR-HighTemp]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Hydrogen-NTR.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hydrogen-NTR.cfg
@@ -1,22 +1,22 @@
-@PART[*]:HAS[@PLUME[Hydrogen-NTR]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Hydrogen-NTR]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Hydrogen-NTR
         {
-            plumeIdentifier = #$/PLUME[Hydrogen-NTR]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Hydrogen-NTR]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hydrogen-NTR]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hydrogen-NTR]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hydrogen-NTR]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hydrogen-NTR]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Hydrogen-NTR]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hydrogen-NTR]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hydrogen-NTR]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hydrogen-NTR]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hydrogen-NTR]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hydrogen-NTR]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hydrogen-NTR]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Hydrogen-NTR]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hydrogen-NTR]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hydrogen-NTR]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hydrogen-NTR]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Hydrogen-NTR]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/flamenuke
                 fixedEmissions = false
                 sizeClamp = 50
@@ -86,11 +86,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Hydrogen-NTR]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Hydrogen-NTR]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Hydrogen-NTR]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hydrogen-NTR]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -103,7 +103,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq7
-                volume = #$/PLUME[Hydrogen-NTR]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hydrogen-NTR]:HAS[~processed[*]]/plumeScale$
                 pitch = 0.8
                 loop = false
             }
@@ -131,7 +131,7 @@
             }
         }
     }
-    @PLUME[Hydrogen-NTR]:HAS[~processed]
+    @PLUME[Hydrogen-NTR]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Hydrolox-Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hydrolox-Lower.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Hydrolox-Lower]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Hydrolox-Lower]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Hydrolox-Lower
         {
-            plumeIdentifier = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/flamessme
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -36,12 +36,12 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumeIdentifier$-shockcone
+                name = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumeIdentifier$-shockcone
                 modelName = RealPlume/MP_Nazari_FX/ssmeflame2big
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -73,15 +73,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumeIdentifier$-plume_red
+                name = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumeIdentifier$-plume_red
                 modelName = RealPlume/MP_Nazari_FX/methanolflame
                 fixedEmissions = false
                 sizeClamp = 50
@@ -158,15 +158,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumeIdentifier$-plume_blue
+                name = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumeIdentifier$-plume_blue
                 modelName = RealPlume/MP_Nazari_FX/noxflame
                 fixedEmissions = false
                 sizeClamp = 50
@@ -243,15 +243,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumeIdentifier$-plume_grey
+                name = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumeIdentifier$-plume_grey
                 modelName = RealPlume/Hoojiwana_FX/MPspike
                 fixedEmissions = false
                 sizeClamp = 50
@@ -329,11 +329,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -346,7 +346,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq4
-                volume = #$/PLUME[Hydrolox-Lower]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hydrolox-Lower]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -374,7 +374,7 @@
             }
         }
     }
-    @PLUME[Hydrolox-Lower]:HAS[~processed]
+    @PLUME[Hydrolox-Lower]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Hydrolox-Upper.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hydrolox-Upper.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Hydrolox-Upper]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Hydrolox-Upper]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Hydrolox-Upper
         {
-            plumeIdentifier = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/flamessme
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -36,15 +36,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/noxflame
                 fixedEmissions = false
                 sizeClamp = 50
@@ -129,15 +129,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/plumeIdentifier$-plume_grey
+                name = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/plumeIdentifier$-plume_grey
                 modelName = RealPlume/Hoojiwana_FX/MPspike
                 fixedEmissions = false
                 sizeClamp = 50
@@ -215,11 +215,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -232,7 +232,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq5
-                volume = #$/PLUME[Hydrolox-Upper]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hydrolox-Upper]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -260,7 +260,7 @@
             }
         }
     }
-    @PLUME[Hydrolox-Upper]:HAS[~processed]
+    @PLUME[Hydrolox-Upper]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Hydynelox-A7.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hydynelox-A7.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Hydynelox-A7]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Hydynelox-A7]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Hydynelox-A7
         {
-            plumeIdentifier = #$/PLUME[Hydynelox-A7]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hydynelox-A7]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hydynelox-A7]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hydynelox-A7]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Hydynelox-A7]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Hydynelox-A7]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/KerbXflame
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -36,15 +36,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hydynelox-A7]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hydynelox-A7]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hydynelox-A7]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hydynelox-A7]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Hydynelox-A7]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hydynelox-A7]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hydynelox-A7]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hydynelox-A7]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/ssmeflame2big
                 fixedEmissions = false
                 sizeClamp = 50
@@ -116,11 +116,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Hydynelox-A7]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Hydynelox-A7]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -133,7 +133,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq4
-                volume = #$/PLUME[Hydynelox-A7]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hydynelox-A7]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -161,7 +161,7 @@
             }
         }
     }
-    @PLUME[Hydynelox-A7]:HAS[~processed]
+    @PLUME[Hydynelox-A7]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Apollo-SM.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Apollo-SM.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Hypergolic-Apollo-SM]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Hypergolic-Apollo-SM
         {
-            plumeIdentifier = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/ssmeflame2
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -36,15 +36,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/ssmeflame2
                 fixedEmissions = false
                 sizeClamp = 50
@@ -121,11 +121,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_spsloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -138,7 +138,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_sps
-                volume = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -166,7 +166,7 @@
             }
         }
     }
-    @PLUME[Hypergolic-Apollo-SM]:HAS[~processed]
+    @PLUME[Hypergolic-Apollo-SM]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Lower.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Hypergolic-Lower]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Hypergolic-Lower]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Hypergolic-Lower
         {
-            plumeIdentifier = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/Ferram_FX/hypergolicflare
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -36,15 +36,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/Ferram_FX/hypergolicexhaust
                 fixedEmissions = false
                 sizeClamp = 50
@@ -132,11 +132,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop2
                 volume = 0.0 0.0
-                volume = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -149,7 +149,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq1
-                volume = #$/PLUME[Hypergolic-Lower]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hypergolic-Lower]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -177,7 +177,7 @@
             }
         }
     }
-    @PLUME[Hypergolic-Lower]:HAS[~processed]
+    @PLUME[Hypergolic-Lower]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic-OMS-Red.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic-OMS-Red.cfg
@@ -1,22 +1,22 @@
-@PART[*]:HAS[@PLUME[Hypergolic-OMS-Red]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Hypergolic-OMS-Red
         {
-            plumeIdentifier = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/KWflamesmall
                 fixedEmissions = false
                 sizeClamp = 50
@@ -110,11 +110,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_spsloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -127,7 +127,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_sps
-                volume = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -155,7 +155,7 @@
             }
         }
     }
-    @PLUME[Hypergolic-OMS-Red]:HAS[~processed]
+    @PLUME[Hypergolic-OMS-Red]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic-OMS-White.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic-OMS-White.cfg
@@ -1,22 +1,22 @@
-@PART[*]:HAS[@PLUME[Hypergolic-OMS-White]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Hypergolic-OMS-White
         {
-            plumeIdentifier = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/flareScale$
-                energy        = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/flareScale$
+                energy        = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/ssmeflame2
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -39,13 +39,13 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/plumeScale$
-                emissionMult  = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/plumeScale$
+                emissionMult  = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/plumeIdentifier$-plumeboundary
+                name = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/plumeIdentifier$-plumeboundary
                 modelName = RealPlume/Hoojiwana_FX/MPmed
                 fixedEmissions = false
                 sizeClamp = 50
@@ -122,11 +122,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_spsloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -139,7 +139,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_sps
-                volume = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -167,7 +167,7 @@
             }
         }
     }
-    @PLUME[Hypergolic-OMS-White]:HAS[~processed]
+    @PLUME[Hypergolic-OMS-White]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Upper.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Upper.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Hypergolic-Upper]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Hypergolic-Upper]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Hypergolic-Upper
         {
-            plumeIdentifier = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/Ferram_FX/hypergolicflare
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -36,15 +36,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/Ferram_FX/hypergolicexhaust
                 fixedEmissions = false
                 sizeClamp = 50
@@ -139,11 +139,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -156,7 +156,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq3
-                volume = #$/PLUME[Hypergolic-Upper]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hypergolic-Upper]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -184,7 +184,7 @@
             }
         }
     }
-    @PLUME[Hypergolic-Upper]:HAS[~processed]
+    @PLUME[Hypergolic-Upper]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Vernier.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic-Vernier.cfg
@@ -1,22 +1,22 @@
-@PART[*]:HAS[@PLUME[Hypergolic-Vernier]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Hypergolic-Vernier]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Hypergolic-Vernier
         {
-            plumeIdentifier = #$/PLUME[Hypergolic-Vernier]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Hypergolic-Vernier]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Hypergolic-Vernier]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Hypergolic-Vernier]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Hypergolic-Vernier]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Hypergolic-Vernier]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Hypergolic-Vernier]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Hypergolic-Vernier]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Hypergolic-Vernier]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Hypergolic-Vernier]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Hypergolic-Vernier]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Hypergolic-Vernier]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Hypergolic-Vernier]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Hypergolic-Vernier]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Hypergolic-Vernier]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Hypergolic-Vernier]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Hypergolic-Vernier]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Hypergolic-Vernier]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/methanolflame
                 fixedEmissions = false
                 sizeClamp = 50
@@ -87,11 +87,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Hypergolic-Vernier]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Hypergolic-Vernier]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Hypergolic-Vernier]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hypergolic-Vernier]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -104,7 +104,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq10
-                volume = #$/PLUME[Hypergolic-Vernier]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Hypergolic-Vernier]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -132,7 +132,7 @@
             }
         }
     }
-    @PLUME[Hypergolic-Vernier]:HAS[~processed]
+    @PLUME[Hypergolic-Vernier]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Ion-Argon-Gridded.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Ion-Argon-Gridded.cfg
@@ -1,23 +1,23 @@
-@PART[*]:HAS[@PLUME[Ion-Argon-Gridded]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Ion-Argon-Gridded]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
 //Blue
     %EFFECTS
     {
         Ion-Argon-Gridded
         {
-            plumeIdentifier = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
-                transformName = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Ion-Argon-Gridded]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/fusionflame
                 randomInitalVelocityOffsetMaxRadius = 0
                 size = 0.5
@@ -50,7 +50,7 @@
             }
         }
     }
-    @PLUME[Ion-Argon-Gridded]:HAS[~processed]
+    @PLUME[Ion-Argon-Gridded]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Ion-Krypton-Gridded.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Ion-Krypton-Gridded.cfg
@@ -1,22 +1,22 @@
-@PART[*]:HAS[@PLUME[Ion-Krypton-Gridded]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Ion-Krypton-Gridded]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Ion-Krypton-Gridded
         {
-            plumeIdentifier = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
-                transformName = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Ion-Krypton-Gridded]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/ssmeflame2
                 transformName = thrustTransform
                 fixedEmissions = false
@@ -38,7 +38,7 @@
             }
         }
     }
-    @PLUME[Ion-Krypton-Gridded]:HAS[~processed]
+    @PLUME[Ion-Krypton-Gridded]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Ion-Krypton-Hall.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Ion-Krypton-Hall.cfg
@@ -1,22 +1,22 @@
-@PART[*]:HAS[@PLUME[Ion-Krypton-Hall]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Ion-Krypton-Hall
         {
-            plumeIdentifier = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
-                transformName = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/plumeIdentifier$-ring
+                name = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/plumeIdentifier$-ring
                 modelName = RealPlume/MP_Nazari_FX/flameionK
                 emission = 0.0 0.0
                 emission = 0.10 0.00
@@ -46,14 +46,14 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
-                transformName = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/flareScale$
-                energy        = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/speed$
+                transformName = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/flareScale$
+                energy        = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/speed$
                 //
-                name = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed]/plumeIdentifier$-core
+                name = #$/PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]/plumeIdentifier$-core
                 modelName = RealPlume/MP_Nazari_FX/flameionK
                 emission = 0.0 0.0
                 emission = 0.10 0.00
@@ -96,7 +96,7 @@
             }
         }
     }
-    @PLUME[Ion-Krypton-Hall]:HAS[~processed]
+    @PLUME[Ion-Krypton-Hall]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Ion-Xenon-Gridded.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Ion-Xenon-Gridded.cfg
@@ -1,22 +1,22 @@
-@PART[*]:HAS[@PLUME[Ion-Xenon-Gridded]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Ion-Xenon-Gridded]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Ion-Xenon-Gridded
         {
-            plumeIdentifier = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
-                transformName = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Ion-Xenon-Gridded]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/noxflame
                 transformName = thrustTransform
                 emission = 0.0 0.0
@@ -44,7 +44,7 @@
             }
         }
     }
-    @PLUME[Ion-Xenon-Gridded]:HAS[~processed]
+    @PLUME[Ion-Xenon-Gridded]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Ion-Xenon-Hall.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Ion-Xenon-Hall.cfg
@@ -1,23 +1,23 @@
-@PART[*]:HAS[@PLUME[Ion-Xenon-Hall]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
 //Blue
     %EFFECTS
     {
         Ion-Xenon-Hall
         {
-            plumeIdentifier = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
-                transformName = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/plumeIdentifier$-ring
+                name = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/plumeIdentifier$-ring
                 modelName = RealPlume/MP_Nazari_FX/flameion
                 fixedEmissions = false
                 energy
@@ -49,15 +49,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
-                transformName = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/flareScale$
-                energy        = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/flareScale$
+                energy        = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed]/plumeIdentifier$-core
+                name = #$/PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]/plumeIdentifier$-core
                 modelName = RealPlume/MP_Nazari_FX/flameion
                 emission = 0.0 0.0
                 emission = 0.10 0.00
@@ -99,7 +99,7 @@
             }
         }
     }
-    @PLUME[Ion-Xenon-Hall]:HAS[~processed]
+    @PLUME[Ion-Xenon-Hall]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower-F1.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower-F1.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Kerolox-Lower-F1]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Kerolox-Lower-F1
         {
-            plumeIdentifier = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/nasaf1
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -41,15 +41,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/KWbooster
                 fixedEmissions = false
                 sizeClamp = 50
@@ -145,13 +145,13 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/plumeScale$
-                emissionMult  = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/plumeScale$
+                emissionMult  = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/plumeIdentifier$-plumeboundary
+                name = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/plumeIdentifier$-plumeboundary
                 modelName = RealPlume/Hoojiwana_FX/MPspike
                 fixedEmissions = false
                 sizeClamp = 50
@@ -243,11 +243,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop2
                 volume = 0.0 0.0
-                volume = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -260,7 +260,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq10
-                volume = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -288,7 +288,7 @@
             }
         }
     }
-    @PLUME[Kerolox-Lower-F1]:HAS[~processed]
+    @PLUME[Kerolox-Lower-F1]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Lower.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Kerolox-Lower]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Kerolox-Lower]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Kerolox-Lower
         {
-            plumeIdentifier = #$/PLUME[Kerolox-Lower]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Kerolox-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Kerolox-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Kerolox-Lower]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Kerolox-Lower]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Kerolox-Lower]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/KWbooster
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -31,15 +31,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Kerolox-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Kerolox-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Kerolox-Lower]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Kerolox-Lower]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Kerolox-Lower]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Kerolox-Lower]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Kerolox-Lower]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Kerolox-Lower]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/KWbooster
                 fixedEmissions = false
                 sizeClamp = 50
@@ -135,13 +135,13 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Kerolox-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Kerolox-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Kerolox-Lower]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Kerolox-Lower]:HAS[~processed]/plumeScale$
-                emissionMult  = #$/PLUME[Kerolox-Lower]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/plumeScale$
+                emissionMult  = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Kerolox-Lower]:HAS[~processed]/plumeIdentifier$-plumeboundary
+                name = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/plumeIdentifier$-plumeboundary
                 modelName = RealPlume/Hoojiwana_FX/MPspike
                 fixedEmissions = false
                 sizeClamp = 50
@@ -233,11 +233,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Kerolox-Lower]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop2
                 volume = 0.0 0.0
-                volume = #$/PLUME[Kerolox-Lower]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -250,7 +250,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq10
-                volume = #$/PLUME[Kerolox-Lower]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Kerolox-Lower]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -278,7 +278,7 @@
             }
         }
     }
-    @PLUME[Kerolox-Lower]:HAS[~processed]
+    @PLUME[Kerolox-Lower]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Upper.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Upper.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Kerolox-Upper]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Kerolox-Upper]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Kerolox-Upper
         {
-            plumeIdentifier = #$/PLUME[Kerolox-Upper]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Kerolox-Upper]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Kerolox-Upper]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Kerolox-Upper]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Kerolox-Upper]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Kerolox-Upper]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/KWbooster
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -31,15 +31,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Kerolox-Upper]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Kerolox-Upper]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Kerolox-Upper]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Kerolox-Upper]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Kerolox-Upper]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Kerolox-Upper]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Kerolox-Upper]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Kerolox-Upper]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/KWbooster
                 fixedEmissions = false
                 sizeClamp = 50
@@ -135,13 +135,13 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Kerolox-Upper]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Kerolox-Upper]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Kerolox-Upper]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Kerolox-Upper]:HAS[~processed]/plumeScale$
-                emissionMult  = #$/PLUME[Kerolox-Upper]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/plumeScale$
+                emissionMult  = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Kerolox-Upper]:HAS[~processed]/plumeIdentifier$-plumeboundary
+                name = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/plumeIdentifier$-plumeboundary
                 modelName = RealPlume/Hoojiwana_FX/MPspike
                 fixedEmissions = false
                 sizeClamp = 50
@@ -241,11 +241,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Kerolox-Upper]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop2
                 volume = 0.0 0.0
-                volume = #$/PLUME[Kerolox-Upper]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -258,7 +258,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq10
-                volume = #$/PLUME[Kerolox-Upper]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Kerolox-Upper]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -286,7 +286,7 @@
             }
         }
     }
-    @PLUME[Kerolox-Upper]:HAS[~processed]
+    @PLUME[Kerolox-Upper]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Vernier.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Vernier.cfg
@@ -1,22 +1,22 @@
-@PART[*]:HAS[@PLUME[Kerolox-Vernier]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Kerolox-Vernier]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Kerolox-Vernier
         {
-            plumeIdentifier = #$/PLUME[Kerolox-Vernier]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Kerolox-Vernier]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Kerolox-Vernier]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Kerolox-Vernier]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Kerolox-Vernier]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Kerolox-Vernier]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Kerolox-Vernier]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Kerolox-Vernier]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Kerolox-Vernier]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Kerolox-Vernier]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Kerolox-Vernier]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Kerolox-Vernier]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Kerolox-Vernier]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Kerolox-Vernier]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Kerolox-Vernier]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Kerolox-Vernier]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Kerolox-Vernier]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Kerolox-Vernier]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = Squad/FX/SRB_Large
                 fixedEmissions = false
                 sizeClamp = 50
@@ -95,11 +95,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Kerolox-Vernier]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Kerolox-Vernier]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Kerolox-Vernier]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Kerolox-Vernier]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -112,7 +112,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_liq10
-                volume = #$/PLUME[Kerolox-Vernier]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Kerolox-Vernier]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -140,7 +140,7 @@
             }
         }
     }
-    @PLUME[Kerolox-Vernier]:HAS[~processed]
+    @PLUME[Kerolox-Vernier]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Solid-Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Solid-Lower.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Solid-Lower]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Solid-Lower]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Solid-Lower
         {
-            plumeIdentifier = #$/PLUME[Solid-Lower]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Solid-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Solid-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Solid-Lower]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Solid-Lower]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Solid-Lower]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/KWbooster
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -31,15 +31,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Solid-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Solid-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Solid-Lower]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Solid-Lower]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Solid-Lower]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Solid-Lower]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Solid-Lower]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Solid-Lower]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/KWbooster
                 fixedEmissions = false
                 sizeClamp = 50
@@ -115,13 +115,13 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Solid-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Solid-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Solid-Lower]:HAS[~processed]/smokePosition$
-                fixedScale    = #$/PLUME[Solid-Lower]:HAS[~processed]/smokeScale$
-                emissionMult  = #$/PLUME[Solid-Lower]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/smokePosition$
+                fixedScale    = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/smokeScale$
+                emissionMult  = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Solid-Lower]:HAS[~processed]/plumeIdentifier$-smoke
+                name = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/plumeIdentifier$-smoke
                 modelName = RealPlume/MP_Nazari_FX/smokelaunch
                 speed = 0.0 1.65
                 speed = 1.0 1.65
@@ -188,12 +188,12 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Solid-Lower]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Solid-Lower]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Solid-Lower]:HAS[~processed]/slagPosition$
-                fixedScale    = #$/PLUME[Solid-Lower]:HAS[~processed]/slagScale$
+                transformName = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/slagPosition$
+                fixedScale    = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/slagScale$
                 //
-                name = #$/PLUME[Solid-Lower]:HAS[~processed]/plumeIdentifier$-slag
+                name = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/plumeIdentifier$-slag
                 modelName = Squad/FX/SRB_Large
                 emission = 0.0 0
                 emission = 0.01 0.05
@@ -228,11 +228,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Solid-Lower]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_srbloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Solid-Lower]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -245,7 +245,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_srb2
-                volume = #$/PLUME[Solid-Lower]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Solid-Lower]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -273,7 +273,7 @@
             }
         }
     }
-    @PLUME[Solid-Lower]:HAS[~processed]
+    @PLUME[Solid-Lower]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Solid-Sepmotor.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Solid-Sepmotor.cfg
@@ -1,22 +1,22 @@
-@PART[*]:HAS[@PLUME[Solid-Sepmotor]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Solid-Sepmotor]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Solid-Sepmotor
         {
-            plumeIdentifier = #$/PLUME[Solid-Sepmotor]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Solid-Sepmotor]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Solid-Sepmotor]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Solid-Sepmotor]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Solid-Sepmotor]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Solid-Sepmotor]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Solid-Sepmotor]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Solid-Sepmotor]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Solid-Sepmotor]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Solid-Sepmotor]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Solid-Sepmotor]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Solid-Sepmotor]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Solid-Sepmotor]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Solid-Sepmotor]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Solid-Sepmotor]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Solid-Sepmotor]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Solid-Sepmotor]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Solid-Sepmotor]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = Squad/FX/SRB_Large
                 fixedEmissions = false
                 sizeClamp = 50
@@ -91,11 +91,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Solid-Sepmotor]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Solid-Sepmotor]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_srbloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Solid-Sepmotor]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Solid-Sepmotor]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -108,7 +108,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_sepmotor
-                volume = #$/PLUME[Solid-Sepmotor]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Solid-Sepmotor]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -136,7 +136,7 @@
             }
         }
     }
-    @PLUME[Solid-Sepmotor]:HAS[~processed]
+    @PLUME[Solid-Sepmotor]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Solid-Upper.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Solid-Upper.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Solid-Upper]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Solid-Upper]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Solid-Upper
         {
-            plumeIdentifier = #$/PLUME[Solid-Upper]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Solid-Upper]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Solid-Upper]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Solid-Upper]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Solid-Upper]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Solid-Upper]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/KWbooster
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -31,15 +31,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Solid-Upper]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Solid-Upper]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Solid-Upper]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Solid-Upper]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Solid-Upper]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Solid-Upper]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Solid-Upper]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Solid-Upper]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/KWbooster
                 fixedEmissions = false
                 sizeClamp = 50
@@ -115,13 +115,13 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Solid-Upper]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Solid-Upper]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Solid-Upper]:HAS[~processed]/smokePosition$
-                fixedScale    = #$/PLUME[Solid-Upper]:HAS[~processed]/smokeScale$
-                emissionMult  = #$/PLUME[Solid-Upper]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/smokePosition$
+                fixedScale    = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/smokeScale$
+                emissionMult  = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Solid-Upper]:HAS[~processed]/plumeIdentifier$-smoke
+                name = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/plumeIdentifier$-smoke
                 modelName = RealPlume/MP_Nazari_FX/smokelaunch
                 speed = 0.0 1.65
                 speed = 1.0 1.65
@@ -188,12 +188,12 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Solid-Upper]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Solid-Upper]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Solid-Upper]:HAS[~processed]/slagPosition$
-                fixedScale    = #$/PLUME[Solid-Upper]:HAS[~processed]/slagScale$
+                transformName = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/slagPosition$
+                fixedScale    = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/slagScale$
                 //
-                name = #$/PLUME[Solid-Upper]:HAS[~processed]/plumeIdentifier$-slag
+                name = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/plumeIdentifier$-slag
                 modelName = Squad/FX/SRB_Large
                 emission = 0.0 0
                 emission = 0.01 0.05
@@ -229,11 +229,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Solid-Upper]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_srbloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Solid-Upper]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -246,7 +246,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_srb3
-                volume = #$/PLUME[Solid-Upper]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Solid-Upper]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -274,7 +274,7 @@
             }
         }
     }
-    @PLUME[Solid-Upper]:HAS[~processed]
+    @PLUME[Solid-Upper]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Solid-Vacuum.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Solid-Vacuum.cfg
@@ -1,19 +1,19 @@
-@PART[*]:HAS[@PLUME[Solid-Vacuum]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Solid-Vacuum]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Solid-Vacuum
         {
-            plumeIdentifier = #$/PLUME[Solid-Vacuum]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Solid-Vacuum]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Solid-Vacuum]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Solid-Vacuum]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Solid-Vacuum]:HAS[~processed]/flareScale$
+                transformName = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[Solid-Vacuum]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/NPflamesmall
                 emission = 0.0 0
                 emission = 0.01 0.2
@@ -31,15 +31,15 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Solid-Vacuum]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Solid-Vacuum]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Solid-Vacuum]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Solid-Vacuum]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Solid-Vacuum]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Solid-Vacuum]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Solid-Vacuum]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Solid-Vacuum]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/NPflamesmall
                 fixedEmissions = false
                 sizeClamp = 50
@@ -110,11 +110,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Solid-Vacuum]:HAS[~processed]/plumeIdentifier$-audio
+                name = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/plumeIdentifier$-audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_srbloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[Solid-Vacuum]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -127,7 +127,7 @@
             {
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_srb2
-                volume = #$/PLUME[Solid-Vacuum]:HAS[~processed]/plumeScale$
+                volume = #$/PLUME[Solid-Vacuum]:HAS[~processed[*]]/plumeScale$
                 pitch = 1.0
                 loop = false
             }
@@ -155,7 +155,7 @@
             }
         }
     }
-    @PLUME[Solid-Vacuum]:HAS[~processed]
+    @PLUME[Solid-Vacuum]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Turbofan.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Turbofan.cfg
@@ -1,22 +1,22 @@
-@PART[*]:HAS[@PLUME[Turbofan]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Turbofan]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Turbofan
         {
-            plumeIdentifier = #$/PLUME[Turbofan]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Turbofan]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
 
-                transformName = #$/PLUME[Turbofan]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Turbofan]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Turbofan]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Turbofan]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Turbofan]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Turbofan]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Turbofan]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Turbofan]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Turbofan]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Turbofan]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Turbofan]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Turbofan]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Turbofan]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Turbofan]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Turbofan]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[Turbofan]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/flamejet3
                 speed = 0.0 1.45
                 speed = 1.0 1.45
@@ -52,15 +52,15 @@
         }
         Turbofan-Spool
         {
-            plumeIdentifier = #$/PLUME[Turbofan]:HAS[~processed]/plumeIdentifier$-spool
+            plumeIdentifier = #$/PLUME[Turbofan]:HAS[~processed[*]]/plumeIdentifier$-spool
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Turbofan]:HAS[~processed]/transformName$
-                fixedScale    = #$/PLUME[Turbofan]:HAS[~processed]/smokeScale$
-                localPosition = #$/PLUME[Turbofan]:HAS[~processed]/smokePosition$
+                transformName = #$/PLUME[Turbofan]:HAS[~processed[*]]/transformName$
+                fixedScale    = #$/PLUME[Turbofan]:HAS[~processed[*]]/smokeScale$
+                localPosition = #$/PLUME[Turbofan]:HAS[~processed[*]]/smokePosition$
                 //
-                name = #$/PLUME[Turbofan]:HAS[~processed]/plumeIdentifier$-smoke
+                name = #$/PLUME[Turbofan]:HAS[~processed[*]]/plumeIdentifier$-smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet
                 fixedEmissions = false
                 sizeClamp = 50
@@ -125,7 +125,7 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Turbofan]:HAS[~processed]/plumeIdentifier$-sndjet1
+                name = #$/PLUME[Turbofan]:HAS[~processed[*]]/plumeIdentifier$-sndjet1
                 channel = Ship
                 clip = sound_jet_low
                 volume = 0.0 0.0
@@ -137,7 +137,7 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Turbofan]:HAS[~processed]/plumeIdentifier$-sndjet2
+                name = #$/PLUME[Turbofan]:HAS[~processed[*]]/plumeIdentifier$-sndjet2
                 channel = Ship
                 clip = sound_jet_deep
                 volume = 0.1 0.0
@@ -177,7 +177,7 @@
 			}
 		}
     }
-    @PLUME[Turbofan]:HAS[~processed]
+    @PLUME[Turbofan]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/Turbojet.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Turbojet.cfg
@@ -1,22 +1,22 @@
-@PART[*]:HAS[@PLUME[Turbojet]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[Turbojet]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         Turbojet
         {
-            plumeIdentifier = #$/PLUME[Turbojet]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[Turbojet]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
-                transformName = #$/PLUME[Turbojet]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Turbojet]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Turbojet]:HAS[~processed]/flarePosition$
-                fixedScale    = #$/PLUME[Turbojet]:HAS[~processed]/flareScale$
-                energy        = #$/PLUME[Turbojet]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Turbojet]:HAS[~processed]/speed$
-                emissionMult  = #$/PLUME[Turbojet]:HAS[~processed]/emissionMult$
+                transformName = #$/PLUME[Turbojet]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Turbojet]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Turbojet]:HAS[~processed[*]]/flarePosition$
+                fixedScale    = #$/PLUME[Turbojet]:HAS[~processed[*]]/flareScale$
+                energy        = #$/PLUME[Turbojet]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Turbojet]:HAS[~processed[*]]/speed$
+                emissionMult  = #$/PLUME[Turbojet]:HAS[~processed[*]]/emissionMult$
                 //
-                name = #$/PLUME[Turbojet]:HAS[~processed]/plumeIdentifier$-flare
+                name = #$/PLUME[Turbojet]:HAS[~processed[*]]/plumeIdentifier$-flare
                 modelName = RealPlume/MP_Nazari_FX/flamejet3
                 emission = 0.0 0.0
                 emission = 0.42 0.0
@@ -48,14 +48,14 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
-                transformName = #$/PLUME[Turbojet]:HAS[~processed]/transformName$
-                localRotation = #$/PLUME[Turbojet]:HAS[~processed]/localRotation$
-                localPosition = #$/PLUME[Turbojet]:HAS[~processed]/plumePosition$
-                fixedScale    = #$/PLUME[Turbojet]:HAS[~processed]/plumeScale$
-                energy        = #$/PLUME[Turbojet]:HAS[~processed]/energy$
-                speed         = #$/PLUME[Turbojet]:HAS[~processed]/speed$
+                transformName = #$/PLUME[Turbojet]:HAS[~processed[*]]/transformName$
+                localRotation = #$/PLUME[Turbojet]:HAS[~processed[*]]/localRotation$
+                localPosition = #$/PLUME[Turbojet]:HAS[~processed[*]]/plumePosition$
+                fixedScale    = #$/PLUME[Turbojet]:HAS[~processed[*]]/plumeScale$
+                energy        = #$/PLUME[Turbojet]:HAS[~processed[*]]/energy$
+                speed         = #$/PLUME[Turbojet]:HAS[~processed[*]]/speed$
                 //
-                name = #$/PLUME[Turbojet]:HAS[~processed]/plumeIdentifier$-afterburner
+                name = #$/PLUME[Turbojet]:HAS[~processed[*]]/plumeIdentifier$-afterburner
                 modelName = RealPlume/MP_Nazari_FX/methanolflame
                 emission = 0.0 0.0
                 emission = 0.42 0.0
@@ -96,7 +96,7 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Turbojet]:HAS[~processed]/plumeIdentifier$-sndjet2
+                name = #$/PLUME[Turbojet]:HAS[~processed[*]]/plumeIdentifier$-sndjet2
                 channel = Ship
                 clip = sound_jet_deep
                 volume = 0.1 0.0
@@ -109,15 +109,15 @@
         }
         Turbojet-Spool
         {
-            plumeIdentifier = #$/PLUME[Turbojet]:HAS[~processed]/plumeIdentifier$-spool
+            plumeIdentifier = #$/PLUME[Turbojet]:HAS[~processed[*]]/plumeIdentifier$-spool
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[Turbojet]:HAS[~processed]/transformName$
-                fixedScale    = #$/PLUME[Turbojet]:HAS[~processed]/smokeScale$
-                localPosition = #$/PLUME[Turbojet]:HAS[~processed]/smokePosition$
+                transformName = #$/PLUME[Turbojet]:HAS[~processed[*]]/transformName$
+                fixedScale    = #$/PLUME[Turbojet]:HAS[~processed[*]]/smokeScale$
+                localPosition = #$/PLUME[Turbojet]:HAS[~processed[*]]/smokePosition$
                 //
-                name = #$/PLUME[Turbojet]:HAS[~processed]/plumeIdentifier$-smoke
+                name = #$/PLUME[Turbojet]:HAS[~processed[*]]/plumeIdentifier$-smoke
                 modelName = RealPlume/MP_Nazari_FX/smokejet
                 fixedEmissions = false
                 sizeClamp = 50
@@ -182,7 +182,7 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Turbojet]:HAS[~processed]/plumeIdentifier$-spool-sndjet1
+                name = #$/PLUME[Turbojet]:HAS[~processed[*]]/plumeIdentifier$-spool-sndjet1
                 channel = Ship
                 clip = sound_jet_low
                 volume = 0.0 0.0
@@ -194,7 +194,7 @@
             }
             AUDIO
             {
-                name = #$/PLUME[Turbojet]:HAS[~processed]/plumeIdentifier$-spool-sndjet2
+                name = #$/PLUME[Turbojet]:HAS[~processed[*]]/plumeIdentifier$-spool-sndjet2
                 channel = Ship
                 clip = sound_jet_deep
                 volume = 0.1 0.0
@@ -234,7 +234,7 @@
 			}
 		}
     }
-    @PLUME[Turbojet]:HAS[~processed]
+    @PLUME[Turbojet]:HAS[~processed[*]]
     {
         processed = true
     }

--- a/GameData/RealPlume/000_Generic_Plumes/zRN_Decoupler.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/zRN_Decoupler.cfg
@@ -1,16 +1,16 @@
-@PART[*]:HAS[@PLUME[zRN_Decoupler]:HAS[~processed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[zRN_Decoupler]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         zRN_Decoupler
         {
-            plumeIdentifier = #$/PLUME[zRN_Decoupler]:HAS[~processed]/plumeIdentifier$
+            plumeIdentifier = #$/PLUME[zRN_Decoupler]:HAS[~processed[*]]/plumeIdentifier$
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get configs from the PLUME node.
-                transformName = #$/PLUME[zRN_Decoupler]:HAS[~processed]/transformName$
+                transformName = #$/PLUME[zRN_Decoupler]:HAS[~processed[*]]/transformName$
                 //
-                name = #$/PLUME[zRN_Decoupler]:HAS[~processed]/plumeIdentifier$-plume
+                name = #$/PLUME[zRN_Decoupler]:HAS[~processed[*]]/plumeIdentifier$-plume
                 modelName = RealPlume/MP_Nazari_FX/flamejet3
                 emission = 0.0 0
                 emission = 1.0 0
@@ -30,7 +30,7 @@
             }
         }
     }
-    @PLUME[zRN_Decoupler]:HAS[~processed]
+    @PLUME[zRN_Decoupler]:HAS[~processed[*]]
     {
         processed = true
     }


### PR DESCRIPTION
They require the value to be specified even if it's * so `:HAS[~processed]` becomes `:HAS[~processed[*]]`