### PR TITLE
Keep original part description

### DIFF
--- a/GameData/RealPlume/000_Generic_Plumes/000_zRealPlume.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/000_zRealPlume.cfg
@@ -1,6 +1,5 @@
 @PART[*]:HAS[@PLUME[*]]:FOR[zRealPlume]:NEEDS[SmokeScreen]
 {
-    @description ^= :$: Plume configured by RealPlume.:
     //Check for all parameters, add a default if parameter is missing.
     @PLUME,*
     {


### PR DESCRIPTION
The hard-coded mention is distracting, especially in localized versions of the game:

French version, currently:
![image](https://user-images.githubusercontent.com/596867/84194079-c847f300-aa9c-11ea-86e1-3415a8101bdb.png)

French version, original:
![image](https://user-images.githubusercontent.com/596867/84194094-cd0ca700-aa9c-11ea-964f-04d86ad8f950.png)

We could translate the string, but I see no real added value, as this is always the same text on all parts.