### PR TITLE
Improve SL plumes in Vac

### DIFF
--- a/GameData/RealPlume/000_Generic_Plumes/Alcolox_Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Alcolox_Lower.cfg
@@ -448,12 +448,12 @@
                 density = 0.19 3
                 density = 0.07 3
                 density = 0.045 3
-                density = 0.02 1.5
+                density = 0.02 2
               }
               energy
               {
                 density = 0.7 2
-                density = 0.02 1
+                density = 0.02 1.5
               }
               logGrow
               {

--- a/GameData/RealPlume/000_Generic_Plumes/HTP_RP1_lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/HTP_RP1_lower.cfg
@@ -448,12 +448,12 @@
                 density = 0.19 3
                 density = 0.07 3
                 density = 0.045 3
-                density = 0.02 1.5
+                density = 0.02 2
               }
               energy
               {
                 density = 0.7 2
-                density = 0.02 1
+                density = 0.02 1.5
               }
               logGrow
               {

--- a/GameData/RealPlume/000_Generic_Plumes/Hydynelox.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hydynelox.cfg
@@ -154,12 +154,12 @@
                 density = 0.19 3
                 density = 0.07 3
                 density = 0.045 3
-                density = 0.02 1.5
+                density = 0.02 2
               }
               energy
               {
                 density = 0.7 2
-                density = 0.02 1
+                density = 0.02 1.5
               }
               logGrow
               {

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic_Aerozine50Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic_Aerozine50Lower.cfg
@@ -462,13 +462,13 @@
                 density = 0.19 3
                 density = 0.07 4
                 density = 0.045 4
-                density = 0.02 1.5
+                density = 0.02 2.5
               }
               energy
               {
                 density = 0.7 2
                 density = 0.07 2
-                density = 0.02 1
+                density = 0.02 1.5
               }
               logGrow
               {

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic_LowerOrangeShock.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic_LowerOrangeShock.cfg
@@ -448,12 +448,12 @@
                 density = 0.19 3
                 density = 0.07 3
                 density = 0.045 3
-                density = 0.02 1.5
+                density = 0.02 2
               }
               energy
               {
                 density = 0.7 2
-                density = 0.02 1
+                density = 0.02 1.5
               }
               logGrow
               {

--- a/GameData/RealPlume/000_Generic_Plumes/Hypergolic_LowerRed_shock.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Hypergolic_LowerRed_shock.cfg
@@ -119,7 +119,7 @@
                 density = 0.19 3
                 density = 0.07 5
                 density = 0.045 5
-                density = 0.02 2
+                density = 0.02 5
               }
               energy
               {
@@ -496,14 +496,14 @@
               density = 0.19 1
               density = 0.07 1
               density = 0.045 1
-              density = 0.02 0.7
+              density = 0.02 1
               }
               linGrow
               {
               density = 0.19 -2
               density = 0.07 -1.3
               density = 0.045 -1
-              density = 0.02 -0.5
+              density = 0.02 1
               }
           }
 

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox-Exhaust.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox-Exhaust.cfg
@@ -34,8 +34,8 @@
                 logGrow
                 {
                     density = 1.0 0.5
-                    density = 0.1 20
-                    density = 0.0 2
+                    density = 0.1 1
+                    density = 0.0 1
                 }
                 logGrowScale
                 {
@@ -44,15 +44,15 @@
                    density = 0.46 2
                    density = 0.2 2
                    density = 0.1 2
-                   density = 0.0 5
+                   density = 0.0 2
                 }
                 linGrow
                 {
                     density = 1.0 -1
                     density = 0.46 4
                     density = 0.2 8
-                    density = 0.05 10
-                    density = 0.0 20
+                    density = 0.05 5
+                    density = 0.0 5
                 }
                 speed
                 {

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox_LowerAlt.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox_LowerAlt.cfg
@@ -175,7 +175,7 @@
                 density = 0.7 1
                 density = 0.07 1
                 density = 0.045 1
-                density = 0.02 0.6
+                density = 0.02 0.7
               }
               emission
               {
@@ -185,8 +185,8 @@
                 density = 0.19 0.5
                 density = 0.07 0.25
                 density = 0.045 0.25
-                density = 0.044 0
-                density = 0.02 0
+                density = 0.044 0.25
+                density = 0.02 0.25
                 power = 0.0      0
                 power = 0.001     0.35
                 power = 0.1     0.5
@@ -196,7 +196,7 @@
               alphaMult
               {
               density = 0.07 1
-              density = 0.045 0
+              density = 0.0 0.7
               }
 
 
@@ -259,7 +259,7 @@
                 density = 0.7 1
                 density = 0.07 1
                 density = 0.045 1
-                density = 0.02 0.4
+                density = 0.02 1
               }
               emission
               {

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox_LowerAlt.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox_LowerAlt.cfg
@@ -257,9 +257,9 @@
               energy
               {
                 density = 0.7 1
-                density = 0.07 1
-                density = 0.045 1
-                density = 0.02 1
+                density = 0.07 1.1
+                density = 0.045 1.25
+                density = 0.02 1.5
               }
               emission
               {

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox_LowerAspirated.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox_LowerAspirated.cfg
@@ -184,7 +184,7 @@
                 density = 0.7 1
                 density = 0.07 1
                 density = 0.045 1
-                density = 0.02 0.6
+                density = 0.02 0.7
               }
               emission
               {
@@ -194,8 +194,8 @@
                 density = 0.19 0.5
                 density = 0.07 0.25
                 density = 0.045 0.25
-                density = 0.044 0
-                density = 0.02 0
+                density = 0.044 0.25
+                density = 0.02 0.25
                 power = 0.0      0
                 power = 0.001     0.35
                 power = 0.1     0.5
@@ -205,7 +205,7 @@
               alphaMult
               {
               density = 0.07 1
-              density = 0.045 0
+              density = 0.0 0.7
               }
 
 
@@ -272,7 +272,7 @@
                 density = 0.7 1
                 density = 0.07 1
                 density = 0.045 1
-                density = 0.02 0.4
+                density = 0.02 1
               }
               emission
               {

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox_LowerAspirated.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox_LowerAspirated.cfg
@@ -270,9 +270,9 @@
               energy
               {
                 density = 0.7 1
-                density = 0.07 1
-                density = 0.045 1
-                density = 0.02 1
+                density = 0.07 1.1
+                density = 0.045 1.25
+                density = 0.02 1.5
               }
               emission
               {

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox_LowerFlame.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox_LowerFlame.cfg
@@ -257,9 +257,9 @@
               energy
               {
                 density = 0.7 1
-                density = 0.07 1
-                density = 0.045 1
-                density = 0.02 1
+                density = 0.07 1.1
+                density = 0.045 1.25
+                density = 0.02 1.5
               }
               emission
               {

--- a/GameData/RealPlume/000_Generic_Plumes/Kerolox_LowerFlame.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Kerolox_LowerFlame.cfg
@@ -175,7 +175,7 @@
                 density = 0.7 1
                 density = 0.07 1
                 density = 0.045 1
-                density = 0.02 0.6
+                density = 0.02 0.7
               }
               emission
               {
@@ -185,8 +185,8 @@
                 density = 0.19 0.5
                 density = 0.07 0.25
                 density = 0.045 0.25
-                density = 0.044 0
-                density = 0.02 0
+                density = 0.044 0.25
+                density = 0.02 0.25
                 power = 0.0      0
                 power = 0.001     0.35
                 power = 0.1     0.5
@@ -196,7 +196,7 @@
               alphaMult
               {
               density = 0.07 1
-              density = 0.045 0
+              density = 0.0 0.7
               }
 
 
@@ -259,14 +259,14 @@
                 density = 0.7 1
                 density = 0.07 1
                 density = 0.045 1
-                density = 0.02 0.4
+                density = 0.02 1
               }
               emission
               {
                 density = 0.7 0
                 density = 0.54 0
                 density = 0.52 0
-               density = 0.21 0
+                density = 0.21 0
                 density = 0.19 0.5
                 density = 0.07 0.5
                 density = 0.045 0.5

--- a/GameData/RealPlume/000_Generic_Plumes/Methalox_LowerShock.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Methalox_LowerShock.cfg
@@ -469,7 +469,7 @@
               energy
               {
                 density = 0.7 2
-                density = 0.02 1
+                density = 0.02 1.5
               }
               logGrow
               {

--- a/GameData/RealPlume/000_Generic_Plumes/Penataborane_Lower.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/Penataborane_Lower.cfg
@@ -448,12 +448,12 @@
                 density = 0.19 3
                 density = 0.07 3
                 density = 0.045 3
-                density = 0.02 1.5
+                density = 0.02 2
               }
               energy
               {
                 density = 0.7 2
-                density = 0.02 1
+                density = 0.02 1.5
               }
               logGrow
               {


### PR DESCRIPTION
Make SL plumes a bit bigger and more energetic in vacuum to better match real life, and their upper stage realplume counterparts. Also improve the behavior of the kerolox-exhaust plume in vaccuum.

Modified plumes have been tested, and they work fine with the same configurations as the unmodified plumes.