### PR TITLE
Update compatibility to include KSP 1.10

### DIFF
--- a/RealPlume.netkan
+++ b/RealPlume.netkan
@@ -2,10 +2,10 @@
 {
     "spec_version"      : "v1.4",
     "$kref"             : "#/ckan/github/KSP-RO/RealPlume",
-    "ksp_version_min"   : "1.1",
-    "ksp_version_max"   : "1.9.99",
+    "ksp_version_min"   : "1.8",
+    "ksp_version_max"   : "1.10",
     "name"              : "Real Plume",
-    "author"	          : [ "Zorg", "Blowfish", "Felger" ],
+    "author"	        : [ "Zorg", "Blowfish", "Felger" ],
     "identifier"        : "RealPlume",
     "abstract"          : "A set of expanding plume effects and basic configs that can be attached to any engine as appropriate.  Requires SmokeScreen and secondary configs to function correctly.",
     "license"           : "CC-BY-NC-SA",


### PR DESCRIPTION
Hi @zorg2044, a forum user pointed out today that RealPlume doesn't show up in CKAN as compatible with KSP 1.10 (the post is invisible right now due to ongoing moderator action, I'll add a link if it comes back). As far as I can tell from the forum thread and SpaceDock, it **is** intended to work with KSP 1.10:

![image](https://user-images.githubusercontent.com/1559108/96194892-f89f1280-0f10-11eb-90ec-d71c10508ef8.png)

Turns out the compatibility is hard coded in the metanetkan, so it has to be updated over here.

- Update max game version from 1.9.99 to 1.10 (the main fix)
- Update min game version from 1.1 to 1.8 based on commonly observed ranges of compatibility (please comment if this release is truly compatible with KSP 1.1 and we can revert this)